### PR TITLE
Patch CVE-2023-45288

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.13.0 // indirect
-	golang.org/x/net v0.21.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.19.0 // indirect
 	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -434,8 +434,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
-golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
Fixes
```
=== Symbol Results ===

Vulnerability #1: GO-2024-2687
    HTTP/2 CONTINUATION flood in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2687
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.21.0
    Fixed in: golang.org/x/net@v0.23.0
    Example traces found:
      #1: testing/datahub.go:38:35: testing.StartTestDatahub calls datahub.NewDatahubInstance, which eventually calls http2.ConnectionError.Error
      #2: jobs/transform.go:61:56: jobs.Importer.Cmd calls fmt.Sprintf, which eventually calls http2.ErrCode.String
      #3: jobs/transform.go:61:56: jobs.Importer.Cmd calls fmt.Sprintf, which eventually calls http2.FrameHeader.String
      #4: jobs/transform.go:61:56: jobs.Importer.Cmd calls fmt.Sprintf, which eventually calls http2.FrameType.String
      #5: testing/datahub.go:38:35: testing.StartTestDatahub calls datahub.NewDatahubInstance, which eventually calls http2.GoAwayError.Error
      #6: jobs/transform.go:61:56: jobs.Importer.Cmd calls fmt.Sprintf, which eventually calls http2.Setting.String
      #7: jobs/transform.go:61:56: jobs.Importer.Cmd calls fmt.Sprintf, which eventually calls http2.SettingID.String
      #8: testing/datahub.go:38:35: testing.StartTestDatahub calls datahub.NewDatahubInstance, which eventually calls http2.StreamError.Error
      #9: testing/entities.go:19:28: testing.LoadEntities calls datahub.Client.StoreEntities, which eventually calls http2.chunkWriter.Write
      #10: testing/datahub.go:38:35: testing.StartTestDatahub calls datahub.NewDatahubInstance, which eventually calls http2.connError.Error
      #11: testing/datahub.go:38:35: testing.StartTestDatahub calls datahub.NewDatahubInstance, which eventually calls http2.duplicatePseudoHeaderError.Error
      #12: testing/entities.go:19:28: testing.LoadEntities calls datahub.Client.StoreEntities, which calls http2.gzipReader.Close
      #13: jobs/template.go:129:28: jobs.ReadFile calls io.ReadAll, which calls http2.gzipReader.Read
      #14: testing/datahub.go:38:35: testing.StartTestDatahub calls datahub.NewDatahubInstance, which eventually calls http2.headerFieldNameError.Error
      #15: testing/datahub.go:38:35: testing.StartTestDatahub calls datahub.NewDatahubInstance, which eventually calls http2.headerFieldValueError.Error
      #16: testing/datahub.go:38:35: testing.StartTestDatahub calls datahub.NewDatahubInstance, which eventually calls http2.pseudoHeaderError.Error
      #17: testing/entities.go:19:28: testing.LoadEntities calls datahub.Client.StoreEntities, which eventually calls http2.stickyErrWriter.Write
      #18: testing/entities.go:19:28: testing.LoadEntities calls datahub.Client.StoreEntities, which calls http2.transportResponseBody.Close
      #19: jobs/template.go:129:28: jobs.ReadFile calls io.ReadAll, which calls http2.transportResponseBody.Read
      #20: jobs/transform.go:61:56: jobs.Importer.Cmd calls fmt.Sprintf, which eventually calls http2.writeData.String

Your code is affected by 1 vulnerability from 1 module.
```