### PR TITLE
fixes comparisons of slices

### DIFF
--- a/testing/entities.go
+++ b/testing/entities.go
@@ -127,7 +127,7 @@ func findMapDiff(expected, result map[string]any, valueType string) []Diff {
 				ResultValue:   nil,
 				ValueType:     valueType,
 			})
-		} else if val != val2 {
+		} else if !reflect.DeepEqual(val, val2) {
 			// Different value in result
 			diffs = append(diffs, Diff{
 				Type:          "diff",


### PR DESCRIPTION
fixes panic: runtime error: comparing uncomparable type []string

if a slice comparison is done and the values compared are [1] vs [1,2] error is thrown.